### PR TITLE
Send status code to error decode function

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	stderrors "errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -1122,7 +1121,7 @@ func stubRespNBody(t *testing.T, status int, v interface{}) *http.Response {
 	}
 	return &http.Response{
 		StatusCode: status,
-		Body:       ioutil.NopCloser(&buf),
+		Body:       io.NopCloser(&buf),
 	}
 }
 
@@ -1134,7 +1133,7 @@ func stubRespHeaders(status int, headers map[string]string) *http.Response {
 
 	return &http.Response{
 		StatusCode: status,
-		Body:       ioutil.NopCloser(new(bytes.Buffer)),
+		Body:       io.NopCloser(new(bytes.Buffer)),
 		Header:     respHeader,
 	}
 }
@@ -1142,7 +1141,7 @@ func stubRespHeaders(status int, headers map[string]string) *http.Response {
 func stubResp(status int) *http.Response {
 	return &http.Response{
 		StatusCode: status,
-		Body:       ioutil.NopCloser(new(bytes.Buffer)),
+		Body:       io.NopCloser(new(bytes.Buffer)),
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	stderrors "errors"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -369,17 +370,21 @@ func TestClient_Req(t *testing.T) {
 
 	t.Run("handling errors response body", func(t *testing.T) {
 		type bar struct{ Name string }
-
 		t.Run("Do", func(t *testing.T) {
 			doer := new(httpcfakes.FakeDoer)
 			expected := bar{Name: "error"}
 			doer.DoReturns(stubRespNBody(t, http.StatusNotFound, expected), nil)
 			client := httpc.New(doer)
 			var actual bar
+			decode := func(r io.Reader, status int) error {
+				assert.Equal(t, http.StatusNotFound, status)
+				return json.NewDecoder(r).Decode(&actual)
+			}
+
 			err := client.
 				DELETE("/foo").
 				Success(httpc.StatusNoContent()).
-				OnError(httpc.JSONDecode(&actual)).
+				OnError(decode).
 				Do(context.TODO())
 			require.Error(t, err)
 
@@ -395,10 +400,14 @@ func TestClient_Req(t *testing.T) {
 			doer.DoReturns(stubRespNBody(t, http.StatusNotFound, expected), nil)
 			client := httpc.New(doer)
 			var actual bar
+			decode := func(r io.Reader, status int) error {
+				assert.Equal(t, http.StatusNotFound, status)
+				return json.NewDecoder(r).Decode(&actual)
+			}
 			resp, err := client.
 				DELETE("/foo").
 				Success(httpc.StatusNoContent()).
-				OnError(httpc.JSONDecode(&actual)).
+				OnError(decode).
 				DoAndGetReader(context.TODO())
 			require.Error(t, err)
 			require.Nil(t, resp)

--- a/encoding.go
+++ b/encoding.go
@@ -13,6 +13,9 @@ type (
 
 	// DecodeFn is a decoder func.
 	DecodeFn func(r io.Reader) error
+
+	// ErrorFn is a decoder func that also gets the status code.
+	ErrorFn func(r io.Reader, status int) error
 )
 
 // JSONEncode sets the client's encodeFn to a json encoder.

--- a/errors/client.go
+++ b/errors/client.go
@@ -57,7 +57,7 @@ func NewClientErr(op string, err error, resp *http.Response, opts ...ClientOptFn
 
 		if req.Header != nil && strings.Contains(req.Header.Get("Content-Type"), "application/json") && req.Body != nil {
 			if body, err := io.ReadAll(req.Body); err == nil {
-				newClientErr.respBody = string(body)
+				newClientErr.reqBody = string(body)
 			}
 		}
 	}

--- a/errors/client.go
+++ b/errors/client.go
@@ -3,7 +3,7 @@ package errors
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -56,7 +56,7 @@ func NewClientErr(op string, err error, resp *http.Response, opts ...ClientOptFn
 		newClientErr.method = req.Method
 
 		if req.Header != nil && strings.Contains(req.Header.Get("Content-Type"), "application/json") && req.Body != nil {
-			if body, err := ioutil.ReadAll(req.Body); err == nil {
+			if body, err := io.ReadAll(req.Body); err == nil {
 				newClientErr.respBody = string(body)
 			}
 		}
@@ -64,7 +64,7 @@ func NewClientErr(op string, err error, resp *http.Response, opts ...ClientOptFn
 	newClientErr.StatusCode = resp.StatusCode
 	newClientErr.reqID = resp.Header.Get(middleware.RequestHeader)
 
-	if body, err := ioutil.ReadAll(resp.Body); err == nil {
+	if body, err := io.ReadAll(resp.Body); err == nil {
 		newClientErr.respBody = string(body)
 	}
 

--- a/errors/client.go
+++ b/errors/client.go
@@ -29,12 +29,15 @@ type ClientErr struct {
 	exists     bool
 }
 
+// ErrUnexpectedResponse is the base error.
+var ErrUnexpectedResponse = errors.New("received unexpected response")
+
 // NewClientErr is a constructor for a client error. The provided options
 // allow the caller to set an optional retry.
 func NewClientErr(op string, err error, resp *http.Response, opts ...ClientOptFn) error {
 	newClientErr := &ClientErr{
 		op:  op,
-		err: errors.New("received unexpected response"),
+		err: ErrUnexpectedResponse,
 	}
 	for _, o := range opts {
 		newClientErr = o(newClientErr)

--- a/middleware/gzip_test.go
+++ b/middleware/gzip_test.go
@@ -3,7 +3,7 @@ package middleware
 import (
 	"bytes"
 	"compress/gzip"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -21,7 +21,7 @@ func TestNoGzip(t *testing.T) {
 	require.NoError(t, err)
 	res, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	b, err := ioutil.ReadAll(res.Body)
+	b, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 	require.Equal(t, body, b)
 }
@@ -39,11 +39,11 @@ func TestGzip(t *testing.T) {
 	require.NoError(t, err)
 	h := res.Header.Get("Content-Encoding")
 	require.Contains(t, h, "gzip")
-	b, err := ioutil.ReadAll(res.Body)
+	b, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 	gr, err := gzip.NewReader(bytes.NewReader(b))
 	require.NoError(t, err)
-	uncompressed, err := ioutil.ReadAll(gr)
+	uncompressed, err := io.ReadAll(gr)
 	require.NoError(t, err)
 	require.Equal(t, body, uncompressed)
 	require.Less(t, len(b), len(body))
@@ -61,7 +61,7 @@ func TestNoContent(t *testing.T) {
 	require.NoError(t, err)
 	h := res.Header.Get("Content-Encoding")
 	require.Contains(t, h, "gzip")
-	b, err := ioutil.ReadAll(res.Body)
+	b, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 	require.Len(t, b, 0)
 }

--- a/request.go
+++ b/request.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	httpcerrors "github.com/ns-jsattler/go-httpc/errors"
@@ -249,7 +248,7 @@ func (r *Request) DoAndGetReader(ctx context.Context) (*http.Response, error) {
 				var buf bytes.Buffer
 				tee := io.TeeReader(resp.Body, &buf)
 				err = r.onErrorFn(tee, status)
-				resp.Body = ioutil.NopCloser(&buf)
+				resp.Body = io.NopCloser(&buf)
 			}
 			return httpcerrors.NewClientErr("status code", err, resp, r.statusErrOpts(status)...)
 		}
@@ -320,7 +319,7 @@ func (r *Request) do(ctx context.Context) error {
 			var buf bytes.Buffer
 			tee := io.TeeReader(resp.Body, &buf)
 			err = r.onErrorFn(tee, status)
-			resp.Body = ioutil.NopCloser(&buf)
+			resp.Body = io.NopCloser(&buf)
 		}
 		return httpcerrors.NewClientErr("status code", err, resp, r.statusErrOpts(status)...)
 	}
@@ -416,7 +415,7 @@ func toKVPairs(pairs []string) []kvPair {
 
 // drain reads everything from the ReadCloser and closes it
 func drain(r io.ReadCloser) error {
-	if _, err := io.Copy(ioutil.Discard, r); err != nil {
+	if _, err := io.Copy(io.Discard, r); err != nil {
 		return err
 	}
 	return r.Close()


### PR DESCRIPTION
Send the status code to the error decode function. This is a sort of type hint for the error response in case you are using different response bodies for different error types. 