### PR TITLE
fix a rare panic

### DIFF
--- a/errors/client.go
+++ b/errors/client.go
@@ -52,7 +52,7 @@ func NewClientErr(op string, err error, resp *http.Response, opts ...ClientOptFn
 		newClientErr.u = *req.URL
 		newClientErr.method = req.Method
 
-		if req.Header != nil && strings.Contains(req.Header.Get("Content-Type"), "application/json") {
+		if req.Header != nil && strings.Contains(req.Header.Get("Content-Type"), "application/json") && req.Body != nil {
 			if body, err := ioutil.ReadAll(req.Body); err == nil {
 				newClientErr.respBody = string(body)
 			}


### PR DESCRIPTION
Fix a panic reading a nil request body. One could argue that I shouldn't have been setting the content type on the request, but I did.

I have an endpoint deliberately returning a 500. This request was causing a panic:
```
client.GET("/error").
		ContentType("application/json").
		Success(httpc.StatusIn(http.StatusOK)).
		RetryStatus(nonRetryStatuses).
		DecodeJSON(&data).
		Header("Accept", "application/json").
		Do(ctx)
```